### PR TITLE
Initial 2015 update (tests now complete successfully)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,12 +6,12 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: ubuntu-13.10
-  - name: ubuntu-13.04
   - name: ubuntu-12.04
+  - name: ubuntu-14.04
 
 suites:
   - name: default
     run_list:
+      - recipe[apt::default]
       - recipe[snapraid::default]
     attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 site :opscode
 
 metadata
+
+cookbook 'apt'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,3 +3,9 @@ default['snapraid']['exclude_list'] = ['*.bak', '*.unrecoverable', '/tmp/', '/lo
 default['snapraid']['data_disks'] = ['/media/disk1', '/media/disk2', '/media/disk3', '/media/disk4']
 default['snapraid']['parity_disks'] = ['/media/p-disk1', '/media/p-disk2']
 default['snapraid']['content_files'] = ['/var/snapraid/content', '/var/disk1/content', '/var/disk2/content']
+
+# Version options
+default['snapraid']['version']['number'] = '7.1'
+default['snapraid']['version']['url'] = 'http://downloads.sourceforge.net/project/snapraid/snapraid-7.1.tar.gz'
+# You will need to calculate the SHA-256 checksum yourself as SourceForge does not provide it
+default['snapraid']['version']['checksum'] = 'dd9005b6d7ea701e4aa0f854a0e34dabe68d7765b75f12fc6b3e1fda4d5c2cef'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,5 +6,4 @@ description      'Installs/Configures snapraid'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.0'
 
-depends 'ark', "= 0.9.0"
-depends 'apt'
+depends 'ark'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,5 @@ description      'Installs/Configures snapraid'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.0'
 
-depends 'ark'
+depends 'ark', "= 0.9.0"
+depends 'apt'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,13 +7,17 @@
 # All rights reserved - Do Not Redistribute
 #
 
+include_recipe 'ark::default'
+
+# Download and build the selected version of SnapRaid
 ark 'snapraid' do
-  url 'http://downloads.sourceforge.net/project/snapraid/snapraid-5.2.tar.gz'
-  version '5.2'
-  checksum 'eab07c21201eceb4204f8039f021ff0032515719aa5e640c330da45dd8b8e7a3'
-  action [:configure, :install_with_make]
+  url node['snapraid']['version']['url']
+  version node['snapraid']['version']['number']
+  checksum node['snapraid']['version']['checksum']
+  action [:install_with_make]
 end
 
+# Ensure the right owner and mode for snapraid install dir
 directory '/etc/snapraid' do
   owner 'root'
   group 'root'


### PR DESCRIPTION
 - Parameterised SnapRAID version
 - Updated default SnapRAID version to latest (7.1)
 - Updated kitchen to latest two Ubuntu LTS versions
 - Added ark::default to default recipe to ensure dependencies are installed
 - Added apt::default to kitchen (could not get ark dependencies to install without it)
 - Removed :configure from ark install of SnapRAID (prevented :install_with_make from running due to the remote_file step common to both already being up-to-date. Bug in chef_ark?)
 - Kitchen test now passes